### PR TITLE
fix: broken github actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,14 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
-          cache: npm
+          bun-version: latest
       - name: Install dependencies
-        run: npm ci
+        run: bun install
       - name: Build
-        run: npm run build
+        run: bun run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Hello dear brother

Your Github actions workflow was attempting to use npm in 2025, which is quite unhinged behavior. I have updated the action to use bun. Enjoy the speed boost and hopefully it builds this time 🤗